### PR TITLE
update container id in test files

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,7 +9,7 @@ describe('Google Tag Manager', function() {
   var analytics;
   var gtm;
   var options = {
-    containerId: 'GTM-K5F78L'
+    containerId: 'GTM-M8M29T'
   };
 
   beforeEach(function() {


### PR DESCRIPTION
Container id was outdated so was throwing 203 errors. Changed to the the container id from our testing account.

@ndhoule @f2prateek 
