### PR TITLE
push userId to data layer for track calls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,9 @@ GTM.prototype.page = function(page) {
 
 GTM.prototype.track = function(track) {
   var props = track.properties();
+  var id = this.analytics.user().id();
+  if (id) props.userId = id;
   props.event = track.event();
+
   push(props);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -67,6 +67,12 @@ describe('Google Tag Manager', function() {
         analytics.called(window.dataLayer.push, { event: 'some-event' });
       });
 
+      it('should send userId if it exists', function() {
+        analytics.user().id('pablo');
+        analytics.track('some-event');
+        analytics.called(window.dataLayer.push, { userId: 'pablo', event: 'some-event' });
+      });
+
       it('should send event with properties', function() {
         analytics.track('event', { prop: true });
         analytics.called(window.dataLayer.push, { event: 'event', prop: true });


### PR DESCRIPTION
fixes https://segment.atlassian.net/browse/INT-450 

@sperand-io 

fyi -- i think we should modify the ajs-tester so that it updates the `analytics.user()` object when you call `analytics.identify()`. Right now it does not do that, meaning that in the `lib/index` I have to use the `analytics.user().id()` to grab the `userId` vs. being able to just use `track.userId()` since the only way to test it is to set the id of the user object directly by using `analytics.user().id(<ID>)`

Or the facade `.userId()` function should fallback on checking the `analytics.user` object -- Right now it just looks up the `.field('userId')` 

DO NOT MERGE: waiting until rollout

TODO:
- [ ] deploy
- [ ] update docs https://github.com/segmentio/site-docs/pull/1556
