### PR TITLE
Add option to prepopulate dataLayer before GTM is initialized.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ var GTM = module.exports = integration('Google Tag Manager')
  */
 
 GTM.prototype.initialize = function() {
+  this.prepopulateDatalayer(this.analytics.options.initialPageview);
   push({ 'gtm.start': Number(new Date()), event: 'gtm.js' });
   this.load(this.ready);
 };
@@ -69,6 +70,21 @@ GTM.prototype.page = function(page) {
   // named
   if (name && opts.trackNamedPages) {
     this.track(page.track(name));
+  }
+};
+
+/**
+ * Prepopulate dataLayer.
+ *
+ * Push pageview properties to dataLayer
+ *
+ * @api private
+ * @param {Pageview} pageview
+ */
+
+GTM.prototype.prepopulateDatalayer = function(pageview) {
+  if (pageview && pageview.properties) {
+    push(pageview.properties);
   }
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,14 @@ var GTM = require('../lib/');
 
 describe('Google Tag Manager', function() {
   var analytics;
+  var analyticsOptions = {
+    initialPageview: {
+      properties: {
+        someId: '1234'
+      }
+    }
+  };
+  var dl;
   var gtm;
   var options = {
     containerId: 'GTM-M8M29T'
@@ -46,15 +54,19 @@ describe('Google Tag Manager', function() {
   describe('after loading', function() {
     beforeEach(function(done) {
       analytics.once('ready', done);
-      analytics.initialize();
+      analytics.initialize({},analyticsOptions);
       analytics.page();
+      dl = window.dataLayer;
     });
 
     it('should push initial gtm.start event', function() {
-      var dl = window.dataLayer;
       analytics.assert(dl);
-      analytics.assert(dl[0].event === 'gtm.js');
-      analytics.assert(typeof dl[0]['gtm.start'] === 'number');
+      analytics.assert(dl[1].event === 'gtm.js');
+      analytics.assert(typeof dl[1]['gtm.start'] === 'number');
+    });
+
+    it('should add pageview properties to dataLayer', function() {
+      analytics.assert(dl[0].someId === '1234');
     });
 
     describe('#track', function() {


### PR DESCRIPTION
Adding a method to allow populating dataLayer with initialPageview properties before GTM is initialized. In some cases, such as the default Page View event, it is required to have dataLayer populated before GTM is initialized.
